### PR TITLE
feat(docker): add Docker dev environment with Caddy TLS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git/
+.github/
+.pytest_cache/
+__pycache__/
+*venv*/
+*.db
+context/
+docs/
+tests/
+*.egg-info/
+dist/
+build/
+.env

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,6 @@ __pycache__/
 *.db
 context/
 docs/
-tests/
 *.egg-info/
 dist/
 build/

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,4 @@
+bookstore.localhost {
+	reverse_proxy app:8000
+	tls internal
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 COPY pyproject.toml .
 COPY app/ app/
+COPY tests/ tests/
 
 RUN pip install --no-cache-dir ".[dev]"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml .
+COPY app/ app/
+
+RUN pip install --no-cache-dir ".[dev]"
+
+RUN mkdir -p /data
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/app/database.py
+++ b/app/database.py
@@ -1,9 +1,10 @@
+import os
 from collections.abc import Generator
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///bookstore.db"
+SQLALCHEMY_DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///bookstore.db")
 
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}

--- a/context/SUMMARY.md
+++ b/context/SUMMARY.md
@@ -6,13 +6,14 @@ This file tracks project state. Every agent session should read this before star
 
 ## Current State
 
-Bookstore API — core REST API implemented with CRUD, search, and ISBN-13 validation.
+Bookstore API — core REST API implemented with CRUD, search, and ISBN-13 validation. Docker development environment with Caddy TLS reverse proxy.
 
 ## Completed Specs
 
 | Spec | Issue | Status | Summary |
 |------|-------|--------|---------|
 | `1-bookstore-rest-api` | #1 | Implemented | FastAPI REST API with Book CRUD, search by title/author, ISBN-13 validation, SQLite storage |
+| `3-docker-dev-environment` | #3 | Implemented | Dockerfile, docker-compose with Caddy TLS, hot-reload via bind mount, SQLite persistence via named volume |
 
 ## Key Decisions
 
@@ -21,3 +22,5 @@ Bookstore API — core REST API implemented with CRUD, search, and ISBN-13 valid
 - **ISBN storage:** Normalized (digits only) for UNIQUE constraint consistency
 - **Search:** `.ilike()` for case-insensitive matching (FTS5 for future scale)
 - **Pagination:** `skip`/`limit` query params, no response envelope
+- **Database URL:** Configurable via `DATABASE_URL` env var, defaults to `sqlite:///bookstore.db`
+- **Dev domain:** `bookstore.localhost` with Caddy internal TLS

--- a/context/specs/3-docker-dev-environment/DECISIONS.md
+++ b/context/specs/3-docker-dev-environment/DECISIONS.md
@@ -1,0 +1,50 @@
+# Decisions: 3-docker-dev-environment
+
+## Accepted
+
+### Dockerfile build failure: package discovery
+- **Source:** Gemini, Codex
+- **Severity:** CRITICAL
+- **Resolution:** Added `[build-system]` and `[tool.setuptools.packages.find]` to `pyproject.toml` in the file plan and implementation order. Scopes package discovery to `app` only, preventing `pip install .` from failing on multiple top-level directories.
+
+### Broken layer caching strategy
+- **Source:** Gemini, Codex
+- **Severity:** CRITICAL
+- **Resolution:** Changed Dockerfile strategy to copy both `pyproject.toml` and `app/` before running `pip install ".[dev]"`. Acknowledged that `pip install .` requires source code present. The bind mount in docker-compose.yml overlays the baked-in code at runtime for hot-reload.
+
+### SQLite persistence requires app code change
+- **Source:** Gemini, Codex
+- **Severity:** CRITICAL (Gemini: HIGH)
+- **Resolution:** Added `app/database.py` to the file plan. Updated to read `DATABASE_URL` from environment with fallback to current default. Container uses `DATABASE_URL=sqlite:////data/bookstore.db` with a named volume at `/data`.
+
+### Hot-reload underspecified for Docker Desktop
+- **Source:** Codex (Gemini: MEDIUM)
+- **Severity:** HIGH
+- **Resolution:** Added `WATCHFILES_FORCE_POLLING=true` as a default environment variable in the app service in docker-compose.yml. Documented in dev guide.
+
+### Test dependencies not installed in image
+- **Source:** Codex
+- **Severity:** HIGH
+- **Resolution:** Changed Dockerfile to install `.[dev]` instead of `.`, so pytest and httpx are available. Added `docker compose exec app pytest` to dev guide and testing section.
+
+### `bookstore.localhost` DNS resolution not universal
+- **Source:** Gemini
+- **Severity:** MEDIUM
+- **Resolution:** Added troubleshooting note to dev guide covering `/etc/hosts` fallback for environments where `*.localhost` doesn't resolve.
+
+### Testing section doesn't verify data persistence
+- **Source:** Codex
+- **Severity:** MEDIUM
+- **Resolution:** Added persistence verification step to testing section: create data, `docker compose down && docker compose up`, verify data persists.
+
+### `.dockerignore` too narrow
+- **Source:** Codex
+- **Severity:** LOW
+- **Resolution:** Changed `.venv/` exclusion to `*venv*/` pattern to cover non-dot virtualenv directories like `test_venv/`.
+
+## Rejected
+
+### Pin specific Python base image patch version
+- **Source:** Gemini
+- **Severity:** LOW
+- **Rationale:** This is a development environment, not a production image. Pinning to `python:3.12-slim` is sufficient — patch-level pinning adds maintenance overhead without meaningful benefit for dev containers.

--- a/context/specs/3-docker-dev-environment/IMPLEMENTATION_SPEC.md
+++ b/context/specs/3-docker-dev-environment/IMPLEMENTATION_SPEC.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Add Docker containerization and docker-compose orchestration for the bookstore API development workflow. The setup uses Caddy as a reverse proxy with automatic internal TLS, mounts the application code as a volume for hot-reload via watchdog/uvicorn `--reload`, and includes a developer guide for getting started.
+Add Docker containerization and docker-compose orchestration for the bookstore API development workflow. The setup uses Caddy as a reverse proxy with automatic internal TLS, mounts the application code as a volume for hot-reload via uvicorn `--reload`, and includes a developer guide for getting started.
 
 ## Source Issue
 
@@ -12,7 +12,7 @@ Add Docker containerization and docker-compose orchestration for the bookstore A
 
 - FastAPI application running on uvicorn (port 8000)
 - SQLite database at `bookstore.db` (relative path, created at working directory)
-- Dependencies managed via `pyproject.toml` (pip-installable)
+- Dependencies managed via `pyproject.toml` (pip-installable, but missing `[build-system]` and package scoping)
 - No containerization, no reverse proxy, no TLS
 - Python >=3.11 required
 
@@ -28,30 +28,36 @@ Add Docker containerization and docker-compose orchestration for the bookstore A
 └──────────────┘       └──────────────┘       └──────────────┘
                         internal TLS            volume mount:
                         auto-certs              ./app → /app/app
+                                                /data → named volume
 ```
 
 ### Key Decisions
 
 1. **Caddy for TLS** — Caddy automatically generates and manages internal (self-signed) TLS certificates. No manual cert generation needed. The `tls internal` directive handles this.
 
-2. **Volume mount for hot-reload** — The `app/` directory is bind-mounted into the container so code changes on the host are immediately visible. Uvicorn's `--reload` flag watches for file changes and restarts the server automatically. No watchdog package needed — uvicorn's built-in file watcher (using `watchfiles` from `uvicorn[standard]`) handles this.
+2. **Volume mount for hot-reload** — The `app/` directory is bind-mounted into the container so code changes on the host are immediately visible. Uvicorn's `--reload` flag watches for file changes and restarts the server automatically. No watchdog package needed — uvicorn's built-in file watcher (using `watchfiles` from `uvicorn[standard]`) handles this. `WATCHFILES_FORCE_POLLING=true` is set in docker-compose.yml to ensure reliable change detection on macOS/Windows Docker Desktop where native filesystem events may not propagate through bind mounts.
 
-3. **SQLite volume** — The database file is stored in a named volume so data persists across container restarts but doesn't pollute the host project directory.
+3. **SQLite persistence via environment variable** — `app/database.py` is updated to read `DATABASE_URL` from the environment with a fallback to the current default (`sqlite:///bookstore.db`). In docker-compose.yml, the app service sets `DATABASE_URL=sqlite:////data/bookstore.db` and mounts a named volume at `/data`. This persists data across container restarts without polluting the host project directory.
 
-4. **Single Dockerfile** — One Dockerfile targeting development use. Production optimization (multi-stage builds, etc.) is out of scope.
+4. **Single Dockerfile with dev dependencies** — One Dockerfile targeting development use. Installs `.[dev]` (includes pytest and httpx) so tests can run inside the container. Production optimization (multi-stage builds, etc.) is out of scope.
 
-5. **Caddy domain** — Use `bookstore.localhost` as the development domain. Most browsers resolve `*.localhost` to `127.0.0.1` without `/etc/hosts` changes.
+5. **Caddy domain** — Use `bookstore.localhost` as the development domain. Most browsers resolve `*.localhost` to `127.0.0.1` without `/etc/hosts` changes. The dev guide includes a troubleshooting note for environments where this doesn't work.
+
+6. **pyproject.toml build configuration** — Add `[build-system]` section and `[tool.setuptools.packages.find]` to scope package discovery to `app` only, preventing `pip install .` from failing due to multiple top-level directories (`app/`, `context/`, `tests/`).
 
 ### Container Configuration
 
-- **App container:** Python 3.12-slim base, installs dependencies from `pyproject.toml`, runs uvicorn with `--reload` and `--host 0.0.0.0`
+- **App container:** Python 3.12-slim base, installs dependencies from `pyproject.toml` (including dev extras), runs uvicorn with `--reload` and `--host 0.0.0.0`, `WATCHFILES_FORCE_POLLING=true` for reliable hot-reload
 - **Caddy container:** Official `caddy:2-alpine` image, reverse proxies HTTPS :443 → app:8000
 
 ## Configuration
 
 ### Environment Variables
 
-None required. The app currently has no environment-variable-based configuration. The SQLite path is hardcoded in `app/database.py`.
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `DATABASE_URL` | `sqlite:///bookstore.db` | SQLAlchemy database connection string. Overridden in docker-compose.yml to `sqlite:////data/bookstore.db` for volume-backed persistence. |
+| `WATCHFILES_FORCE_POLLING` | (unset) | Set to `true` in docker-compose.yml to ensure file change detection works through bind mounts on Docker Desktop. |
 
 ### Caddyfile
 
@@ -71,54 +77,85 @@ bookstore.localhost {
 | `Caddyfile` | Create | Caddy reverse proxy configuration |
 | `.dockerignore` | Create | Exclude unnecessary files from build context |
 | `docs/docker-dev-guide.md` | Create | Developer guide for Docker-based workflow |
-
-No existing files need modification.
+| `app/database.py` | Modify | Read `DATABASE_URL` from environment with fallback to current default |
+| `pyproject.toml` | Modify | Add `[build-system]` and `[tool.setuptools.packages.find]` sections |
 
 ## Implementation Order
 
-### Step 1: Create `.dockerignore`
+### Step 1: Update `pyproject.toml`
 
-Exclude `.venv/`, `*.db`, `.git/`, `__pycache__/`, `.pytest_cache/`, `context/`, `.github/` from the Docker build context.
+Add `[build-system]` section specifying `setuptools` as the build backend. Add `[tool.setuptools.packages.find]` to include only the `app` package, preventing discovery of `context/` and `tests/` as top-level packages.
+
+```toml
+[build-system]
+requires = ["setuptools>=75.0.0"]
+build-backend = "setuptools.backends._legacy:_Backend"
+
+[tool.setuptools.packages.find]
+include = ["app*"]
+```
+
+**Verify:** `pip install .` succeeds in a clean virtual environment.
+
+### Step 2: Update `app/database.py`
+
+Read `DATABASE_URL` from `os.environ` with a fallback to the current hardcoded value:
+
+```python
+import os
+SQLALCHEMY_DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///bookstore.db")
+```
+
+This is a minimal change — existing behavior is preserved when the variable is not set.
+
+**Verify:** App still starts normally without the env var set. Tests still pass.
+
+### Step 3: Create `.dockerignore`
+
+Exclude `.venv/`, `*venv*/`, `*.db`, `.git/`, `__pycache__/`, `.pytest_cache/`, `context/`, `.github/` from the Docker build context.
 
 **Verify:** File exists and lists appropriate exclusions.
 
-### Step 2: Create `Dockerfile`
+### Step 4: Create `Dockerfile`
 
 - Base image: `python:3.12-slim`
 - Set working directory to `/app`
-- Copy `pyproject.toml` first (layer caching for dependencies)
-- Install dependencies with `pip install .`
-- Copy application code
+- Copy `pyproject.toml` and `app/` directory
+- Install with `pip install ".[dev]"` (includes test dependencies)
+- Create `/data` directory for SQLite volume mount
 - Expose port 8000
 - CMD: `uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload`
 
+Note: Both `pyproject.toml` and `app/` must be copied before `pip install` because `pip install .` builds the project from source. Layer caching still helps — these layers only rebuild when dependencies or app code change. The bind mount in docker-compose.yml overlays the baked-in `app/` at runtime for hot-reload.
+
 **Verify:** `docker build -t bookstore-api .` succeeds.
 
-### Step 3: Create `Caddyfile`
+### Step 5: Create `Caddyfile`
 
 Configure `bookstore.localhost` with `reverse_proxy app:8000` and `tls internal`.
 
 **Verify:** File is valid Caddy configuration syntax.
 
-### Step 4: Create `docker-compose.yml`
+### Step 6: Create `docker-compose.yml`
 
 Two services:
-- **app**: builds from `Dockerfile`, mounts `./app:/app/app` for hot-reload, exposes port 8000 (optional, for direct API access), depends on nothing
+- **app**: builds from `Dockerfile`, mounts `./app:/app/app` for hot-reload, mounts named volume `bookstore_data` at `/data` for SQLite persistence, sets `DATABASE_URL=sqlite:////data/bookstore.db` and `WATCHFILES_FORCE_POLLING=true`, exposes port 8000 (optional, for direct API access)
 - **caddy**: uses `caddy:2-alpine`, mounts `Caddyfile`, publishes ports 443 and 80, depends on `app`, uses named volumes for Caddy data/config
 
-Volumes: `caddy_data`, `caddy_config`
+Volumes: `caddy_data`, `caddy_config`, `bookstore_data`
 
 **Verify:** `docker compose config` validates without errors.
 
-### Step 5: Create `docs/docker-dev-guide.md`
+### Step 7: Create `docs/docker-dev-guide.md`
 
 Write a concise developer guide covering:
 - Prerequisites (Docker, docker compose plugin)
 - Starting the environment (`docker compose up`)
 - Accessing the API (`https://bookstore.localhost`)
 - How hot-reload works
-- Trusting the Caddy internal CA (optional, for browsers)
-- Running tests inside the container
+- Troubleshooting: `*.localhost` DNS resolution (add `/etc/hosts` entry if needed)
+- Troubleshooting: hot-reload not working (`WATCHFILES_FORCE_POLLING` is already set, but document it)
+- Running tests inside the container (`docker compose exec app pytest`)
 - Stopping and cleaning up
 
 **Verify:** Guide is accurate and follows the actual setup.
@@ -129,6 +166,8 @@ Write a concise developer guide covering:
 - `https://bookstore.localhost/docs` loads the FastAPI Swagger UI (after accepting self-signed cert)
 - Modify a file in `app/` on the host → uvicorn auto-reloads inside the container
 - API endpoints respond correctly through Caddy (e.g., `curl -k https://bookstore.localhost/books`)
+- **Data persistence:** Create a book via the API, run `docker compose down && docker compose up`, verify the book still exists
+- `docker compose exec app pytest` runs tests successfully inside the container
 - `docker compose down` stops cleanly
 
 All testing is manual — no new automated tests are needed for containerization.
@@ -139,5 +178,4 @@ All testing is manual — no new automated tests are needed for containerization
 - Production-ready Dockerfile (multi-stage builds, non-root user, etc.)
 - Dev containers / VS Code devcontainer configuration (noted as future work in the issue)
 - CI/CD pipeline changes
-- Environment variable configuration system
 - Database migration tooling

--- a/context/specs/3-docker-dev-environment/IMPLEMENTATION_SPEC.md
+++ b/context/specs/3-docker-dev-environment/IMPLEMENTATION_SPEC.md
@@ -1,0 +1,143 @@
+# Implementation Spec: Docker Development Environment
+
+## Overview
+
+Add Docker containerization and docker-compose orchestration for the bookstore API development workflow. The setup uses Caddy as a reverse proxy with automatic internal TLS, mounts the application code as a volume for hot-reload via watchdog/uvicorn `--reload`, and includes a developer guide for getting started.
+
+## Source Issue
+
+[#3 — Dockerfile and docker compose support for development environment](https://github.com/BSpendlove/baf-walkthrough-python-bookstore/issues/3)
+
+## Current State
+
+- FastAPI application running on uvicorn (port 8000)
+- SQLite database at `bookstore.db` (relative path, created at working directory)
+- Dependencies managed via `pyproject.toml` (pip-installable)
+- No containerization, no reverse proxy, no TLS
+- Python >=3.11 required
+
+## Design
+
+### Architecture
+
+```
+┌──────────────┐       ┌──────────────┐       ┌──────────────┐
+│   Browser    │──TLS──│    Caddy      │──HTTP──│   App (API)  │
+│              │ :443  │  (reverse     │ :8000  │  (uvicorn    │
+│              │       │   proxy)      │        │   --reload)  │
+└──────────────┘       └──────────────┘       └──────────────┘
+                        internal TLS            volume mount:
+                        auto-certs              ./app → /app/app
+```
+
+### Key Decisions
+
+1. **Caddy for TLS** — Caddy automatically generates and manages internal (self-signed) TLS certificates. No manual cert generation needed. The `tls internal` directive handles this.
+
+2. **Volume mount for hot-reload** — The `app/` directory is bind-mounted into the container so code changes on the host are immediately visible. Uvicorn's `--reload` flag watches for file changes and restarts the server automatically. No watchdog package needed — uvicorn's built-in file watcher (using `watchfiles` from `uvicorn[standard]`) handles this.
+
+3. **SQLite volume** — The database file is stored in a named volume so data persists across container restarts but doesn't pollute the host project directory.
+
+4. **Single Dockerfile** — One Dockerfile targeting development use. Production optimization (multi-stage builds, etc.) is out of scope.
+
+5. **Caddy domain** — Use `bookstore.localhost` as the development domain. Most browsers resolve `*.localhost` to `127.0.0.1` without `/etc/hosts` changes.
+
+### Container Configuration
+
+- **App container:** Python 3.12-slim base, installs dependencies from `pyproject.toml`, runs uvicorn with `--reload` and `--host 0.0.0.0`
+- **Caddy container:** Official `caddy:2-alpine` image, reverse proxies HTTPS :443 → app:8000
+
+## Configuration
+
+### Environment Variables
+
+None required. The app currently has no environment-variable-based configuration. The SQLite path is hardcoded in `app/database.py`.
+
+### Caddyfile
+
+```
+bookstore.localhost {
+    reverse_proxy app:8000
+    tls internal
+}
+```
+
+## File Plan
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `Dockerfile` | Create | Python container for the bookstore API |
+| `docker-compose.yml` | Create | Orchestrate app + Caddy services |
+| `Caddyfile` | Create | Caddy reverse proxy configuration |
+| `.dockerignore` | Create | Exclude unnecessary files from build context |
+| `docs/docker-dev-guide.md` | Create | Developer guide for Docker-based workflow |
+
+No existing files need modification.
+
+## Implementation Order
+
+### Step 1: Create `.dockerignore`
+
+Exclude `.venv/`, `*.db`, `.git/`, `__pycache__/`, `.pytest_cache/`, `context/`, `.github/` from the Docker build context.
+
+**Verify:** File exists and lists appropriate exclusions.
+
+### Step 2: Create `Dockerfile`
+
+- Base image: `python:3.12-slim`
+- Set working directory to `/app`
+- Copy `pyproject.toml` first (layer caching for dependencies)
+- Install dependencies with `pip install .`
+- Copy application code
+- Expose port 8000
+- CMD: `uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload`
+
+**Verify:** `docker build -t bookstore-api .` succeeds.
+
+### Step 3: Create `Caddyfile`
+
+Configure `bookstore.localhost` with `reverse_proxy app:8000` and `tls internal`.
+
+**Verify:** File is valid Caddy configuration syntax.
+
+### Step 4: Create `docker-compose.yml`
+
+Two services:
+- **app**: builds from `Dockerfile`, mounts `./app:/app/app` for hot-reload, exposes port 8000 (optional, for direct API access), depends on nothing
+- **caddy**: uses `caddy:2-alpine`, mounts `Caddyfile`, publishes ports 443 and 80, depends on `app`, uses named volumes for Caddy data/config
+
+Volumes: `caddy_data`, `caddy_config`
+
+**Verify:** `docker compose config` validates without errors.
+
+### Step 5: Create `docs/docker-dev-guide.md`
+
+Write a concise developer guide covering:
+- Prerequisites (Docker, docker compose plugin)
+- Starting the environment (`docker compose up`)
+- Accessing the API (`https://bookstore.localhost`)
+- How hot-reload works
+- Trusting the Caddy internal CA (optional, for browsers)
+- Running tests inside the container
+- Stopping and cleaning up
+
+**Verify:** Guide is accurate and follows the actual setup.
+
+## Testing
+
+- `docker compose up --build` starts both containers without errors
+- `https://bookstore.localhost/docs` loads the FastAPI Swagger UI (after accepting self-signed cert)
+- Modify a file in `app/` on the host → uvicorn auto-reloads inside the container
+- API endpoints respond correctly through Caddy (e.g., `curl -k https://bookstore.localhost/books`)
+- `docker compose down` stops cleanly
+
+All testing is manual — no new automated tests are needed for containerization.
+
+## Not In Scope
+
+- Docker installation instructions (issue explicitly excludes this)
+- Production-ready Dockerfile (multi-stage builds, non-root user, etc.)
+- Dev containers / VS Code devcontainer configuration (noted as future work in the issue)
+- CI/CD pipeline changes
+- Environment variable configuration system
+- Database migration tooling

--- a/context/specs/3-docker-dev-environment/README.md
+++ b/context/specs/3-docker-dev-environment/README.md
@@ -1,0 +1,33 @@
+# 3 — Docker Development Environment
+
+Docker container and docker-compose setup with Caddy reverse proxy (internal TLS) for local development with hot-reload.
+
+## Source Issue
+
+[#3 — Dockerfile and docker compose support for development environment](https://github.com/BSpendlove/baf-walkthrough-python-bookstore/issues/3)
+
+## Status
+
+| Phase | Status | Agent |
+|-------|--------|-------|
+| spec-create | Complete | Claude |
+| spec-review | Not Started | — |
+| spec-critique | Not Started | — |
+| spec-finalize | Not Started | — |
+| spec-implement | Not Started | — |
+| spec-final-review | Not Started | — |
+
+## Key Files
+
+- `context/specs/3-docker-dev-environment/IMPLEMENTATION_SPEC.md` — Implementation spec
+- `context/specs/3-docker-dev-environment/README.md` — This status tracker
+
+## Dependencies
+
+### Upstream
+
+- Issue #1 (Bookstore REST API) — must be implemented (it is)
+
+### Downstream
+
+- None currently

--- a/context/specs/3-docker-dev-environment/README.md
+++ b/context/specs/3-docker-dev-environment/README.md
@@ -11,7 +11,7 @@ Docker container and docker-compose setup with Caddy reverse proxy (internal TLS
 | Phase | Status | Agent |
 |-------|--------|-------|
 | spec-create | Complete | Claude |
-| spec-review | Not Started | — |
+| spec-review | Complete | Gemini |
 | spec-critique | Not Started | — |
 | spec-finalize | Not Started | — |
 | spec-implement | Not Started | — |

--- a/context/specs/3-docker-dev-environment/README.md
+++ b/context/specs/3-docker-dev-environment/README.md
@@ -12,8 +12,8 @@ Docker container and docker-compose setup with Caddy reverse proxy (internal TLS
 |-------|--------|-------|
 | spec-create | Complete | Claude |
 | spec-review | Complete | Gemini |
-| spec-critique | Not Started | — |
-| spec-finalize | Not Started | — |
+| spec-critique | Complete | Codex |
+| spec-finalize | Complete | Claude |
 | spec-implement | Not Started | — |
 | spec-final-review | Not Started | — |
 
@@ -21,6 +21,9 @@ Docker container and docker-compose setup with Caddy reverse proxy (internal TLS
 
 - `context/specs/3-docker-dev-environment/IMPLEMENTATION_SPEC.md` — Implementation spec
 - `context/specs/3-docker-dev-environment/README.md` — This status tracker
+- `context/specs/3-docker-dev-environment/DECISIONS.md` — Accept/reject rationale
+- `context/specs/3-docker-dev-environment/spec-reviews/GEMINI.md` — Spec review
+- `context/specs/3-docker-dev-environment/spec-reviews/CRITIQUE.md` — Spec critique
 
 ## Dependencies
 

--- a/context/specs/3-docker-dev-environment/README.md
+++ b/context/specs/3-docker-dev-environment/README.md
@@ -14,7 +14,7 @@ Docker container and docker-compose setup with Caddy reverse proxy (internal TLS
 | spec-review | Complete | Gemini |
 | spec-critique | Complete | Codex |
 | spec-finalize | Complete | Claude |
-| spec-implement | Not Started | — |
+| spec-implement | Complete | Claude |
 | spec-final-review | Not Started | — |
 
 ## Key Files

--- a/context/specs/3-docker-dev-environment/code-reviews/CODEX.md
+++ b/context/specs/3-docker-dev-environment/code-reviews/CODEX.md
@@ -1,0 +1,11 @@
+# Code Review: 3-docker-dev-environment
+
+## Findings
+
+### HIGH: In-container test workflow from the spec cannot run the repository test suite
+- **Files:** `Dockerfile:5-8`, `.dockerignore:8-9`, `docs/docker-dev-guide.md:39-45`
+- The finalized spec requires `docker compose exec app pytest` to work, and the guide tells developers to use that command. The image never copies `tests/` into `/app`, and `.dockerignore` explicitly excludes `tests/`, so the container does not contain the repository test suite. In practice, `pytest` inside the `app` container cannot execute the project tests that the spec says should be runnable there.
+
+### MEDIUM: The guide says containerized tests do not touch the development database, but the app lifespan still initializes the persistent engine
+- **Files:** `docs/docker-dev-guide.md:41-47`, `app/main.py:10-13`, `tests/conftest.py:26-39`, `docker-compose.yml:7-9`
+- The guide states that tests "do not affect the development database." However, `docker compose exec app pytest` runs with `DATABASE_URL=sqlite:////data/bookstore.db`, and `TestClient(app)` triggers the FastAPI lifespan, which calls `Base.metadata.create_all(bind=engine)` on the persistent app engine before each test client session. Request handling is redirected to the in-memory override, but the persistent database file is still initialized from the test run, so the documentation overstates the isolation guarantee.

--- a/context/specs/3-docker-dev-environment/code-reviews/GEMINI.md
+++ b/context/specs/3-docker-dev-environment/code-reviews/GEMINI.md
@@ -1,0 +1,43 @@
+# Code Review: 3-docker-dev-environment
+
+Post-implementation code review for the Docker development environment.
+
+## Summary
+
+The implementation is high quality and strictly adheres to the finalized specification. It successfully incorporates all critical fixes identified during the `spec-review` and `spec-critique` phases, particularly regarding the `Dockerfile` build strategy, `pyproject.toml` package scoping, and SQLite persistence.
+
+**Findings by Severity:**
+- **CRITICAL:** 0
+- **HIGH:** 0
+- **MEDIUM:** 0
+- **LOW:** 2
+
+## Findings
+
+### LOW
+
+#### 1. Inefficient Layer Caching in Dockerfile
+- **File:** `Dockerfile:4-6`
+- **Description:** The `Dockerfile` copies the entire `app/` directory before running `pip install ".[dev]"`. This means any change to the application code will invalidate the layer cache for the dependency installation, causing a full reinstall if the image is rebuilt. While the spec accepted this trade-off for simplicity with `pip install .`, it makes manual image rebuilds slower than they could be.
+- **Spec Compliance:** Compliant (Matches Decision: "Broken layer caching strategy").
+
+#### 2. Root user in development container
+- **File:** `Dockerfile:1`
+- **Description:** The container runs as the `root` user. While standard for many development environments, it can lead to file permission issues on the host machine for any files created by the container (like the SQLite database in the volume). Since the spec explicitly excluded "Production-ready Dockerfile (non-root user, etc.)", this is acceptable but worth noting.
+- **Spec Compliance:** Compliant (Matches "Not In Scope").
+
+## Spec Compliance Audit
+
+| Requirement | Status | Note |
+|-------------|--------|------|
+| Dockerfile with Python 3.12-slim | ✅ Pass | |
+| Caddy reverse proxy with internal TLS | ✅ Pass | `bookstore.localhost` works as expected. |
+| Hot-reload via bind mount | ✅ Pass | Includes `WATCHFILES_FORCE_POLLING=true`. |
+| SQLite persistence via named volume | ✅ Pass | `DATABASE_URL` correctly configured. |
+| Developer guide in `docs/` | ✅ Pass | Comprehensive and accurate. |
+| `pyproject.toml` build config | ✅ Pass | Correctly scoped to `app*`. |
+| `app/database.py` env var | ✅ Pass | Backward-compatible fallback. |
+
+## Conclusion
+
+The implementation is complete and ready for merge. The developer experience is significantly improved with the addition of one-command startup, automatic TLS, and persistent storage.

--- a/context/specs/3-docker-dev-environment/spec-reviews/CRITIQUE.md
+++ b/context/specs/3-docker-dev-environment/spec-reviews/CRITIQUE.md
@@ -1,0 +1,39 @@
+# Spec Critique: 3-docker-dev-environment
+
+**Agent:** Codex
+**Date:** 2026-03-24
+
+## Summary
+The spec is directionally sound, but it currently has several concrete implementation gaps against this repository. As written, the Docker build order will fail, the SQLite persistence plan cannot work without changing application configuration, and the container setup does not account for the common bind-mount reload failure mode on Docker Desktop. There is also a mismatch between the guide's promised "run tests inside the container" workflow and the dependencies installed into the app image.
+
+## Findings
+
+### Dependency install order in the Dockerfile will fail
+- **Severity:** CRITICAL
+- **Description:** Step 2 says to copy only `pyproject.toml`, run `pip install .`, and copy the application code afterward. In this repository, `pip install .` installs the local project package, which requires the `app/` package to already be present in the build context inside the image. Running the install before copying `app/` will fail the image build, so the spec's own verification command (`docker build -t bookstore-api .`) is not achievable as written.
+- **Suggested Resolution:** Change the Dockerfile plan so dependency installation does not require the application package before it is copied. For example, either copy `app/` before `pip install .`, or split dependency installation from project installation with an approach the repo can actually support.
+
+### SQLite persistence design is impossible without changing the app's database path
+- **Severity:** CRITICAL
+- **Description:** The spec says the SQLite database should live in a named volume, while also saying no existing files need modification and the database path remains hardcoded in `app/database.py`. Today the app uses `sqlite:///bookstore.db`, which resolves relative to the working directory. A named volume cannot persist that file cleanly unless the container mounts over the path the app actually writes to, and mounting a volume broadly enough to catch that file would conflict with the application files at `/app`. The persistence design therefore cannot be implemented as specified without changing application configuration or the database path strategy.
+- **Suggested Resolution:** Update the spec to include an application configuration change for the database location, preferably via an environment variable with a container-specific path mounted from a named volume. If changing app code is intentionally out of scope, then drop the named-volume persistence requirement and state that the containerized dev database is ephemeral.
+
+### Hot-reload is underspecified for bind mounts on Docker Desktop
+- **Severity:** HIGH
+- **Description:** The issue acceptance criteria require hot-reload without rebuilding. The spec assumes `uvicorn --reload` alone is sufficient because `uvicorn[standard]` includes `watchfiles`. That is not enough on many Docker Desktop setups, where filesystem events from bind-mounted host files are not delivered reliably into the container. In practice this often requires polling mode for the watcher. Without accounting for that runtime setting, the spec risks missing one of the main promised outcomes on macOS and Windows development environments.
+- **Suggested Resolution:** Explicitly define the file-watch strategy for containerized bind mounts, including the required environment variable or reload configuration needed when native file events are unavailable. The testing section should verify reload from a host edit, not just container startup.
+
+### The guide promises in-container test execution, but the image does not install test dependencies
+- **Severity:** HIGH
+- **Description:** Step 5 says the developer guide should cover running tests inside the container, but Step 2 installs only `pip install .`. In this repo, test tooling lives under the `dev` extra in `pyproject.toml` (`pytest` and `httpx`). As specified, the app image would not contain those dependencies, so the documented workflow would fail or force an undocumented second installation path.
+- **Suggested Resolution:** Decide whether the development image is expected to run tests. If yes, update the spec so the image installs `.[dev]` or otherwise includes test dependencies. If no, remove the "run tests inside the container" requirement from the guide.
+
+### The testing section does not verify the spec's claimed data persistence behavior
+- **Severity:** MEDIUM
+- **Description:** The design calls out a named volume so the SQLite database persists across container restarts, but the Testing section only verifies startup, endpoint access, reload, and shutdown. It never checks the one behavior that justifies introducing the database volume. That leaves a core design claim untested.
+- **Suggested Resolution:** Add an explicit persistence test: create data, restart the app stack, and verify the records are still present. If persistence is no longer required after spec revision, remove the named-volume claim from the design.
+
+### The `.dockerignore` plan does not account for the repo's existing local virtualenv naming
+- **Severity:** LOW
+- **Description:** The `.dockerignore` step excludes `.venv/`, but this working tree already contains `test_venv/`. If a developer has any non-dot virtualenv directory or similar local artifact, it will still be sent in the Docker build context. That is avoidable build bloat and slows the main dev workflow this issue is trying to improve.
+- **Suggested Resolution:** Broaden the ignore patterns to cover common virtualenv and local artifact directories beyond `.venv/`, or explicitly ignore `test_venv/` for this repository.

--- a/context/specs/3-docker-dev-environment/spec-reviews/GEMINI.md
+++ b/context/specs/3-docker-dev-environment/spec-reviews/GEMINI.md
@@ -1,0 +1,59 @@
+# Spec Review: Docker Development Environment (Issue #3)
+
+**Agent:** Gemini
+**Status:** COMPLETE
+**Review Date:** 2026-03-24
+
+## Summary
+
+The specification provides a solid foundation for a Docker-based development environment using a modern stack (Caddy + FastAPI + uvicorn). The decision to use `bookstore.localhost` for automatic DNS resolution and Caddy's `tls internal` for automatic TLS management is excellent for developer experience.
+
+However, there are critical technical blockers in the proposed `Dockerfile` build process and the implementation of data persistence that must be addressed before implementation begins.
+
+---
+
+## Findings
+
+### CRITICAL
+
+#### 1. Dockerfile Build Failure: Package Discovery
+- **Severity:** CRITICAL
+- **Description:** The proposed `pip install .` command will fail because the project structure cannot be automatically discovered by the default `setuptools` backend. Running `pip install .` on the current codebase results in an error: `Multiple top-level packages discovered in a flat-layout: ['app', 'context', 'tests']`. This is because `pyproject.toml` lacks a `[build-system]` section and explicit `[tool.setuptools]` package configuration.
+- **Suggested Resolution:** Modify `pyproject.toml` to include a `[build-system]` section and specify that only the `app` directory should be treated as a package, OR use a different method to install dependencies (e.g., a temporary `requirements.txt` or a tool like `uv`).
+
+#### 2. Broken Layer Caching Strategy
+- **Severity:** CRITICAL
+- **Description:** Step 2 of the Implementation Order proposes copying `pyproject.toml` and then running `pip install .` to cache dependencies. However, `pip install .` (even with the `--no-deps` flag) requires the package source code to be present to build the project. Since only `pyproject.toml` is copied before the install command, the build will fail at this step.
+- **Suggested Resolution:** If the goal is layer caching, use a tool that can install dependencies without building the project (like `pip install -r requirements.txt`), or copy the `app/` directory *before* the `pip install .` command (acknowledging that this reduces cache efficiency if source code changes).
+
+### HIGH
+
+#### 1. Missing SQLite Data Persistence
+- **Severity:** HIGH
+- **Description:** Decision 3 states that "data persists across container restarts but doesn't pollute the host project directory" using a named volume. However, the Implementation Plan (Step 4) only lists a bind-mount for the source code and named volumes for Caddy. It does not provide a volume for the `bookstore.db` file. Since the database is created at `/app/bookstore.db` (in the container's root working directory), it will be lost whenever the container is removed (e.g., during `docker compose down` or image updates).
+- **Suggested Resolution:** Mount a named volume to a directory (e.g., `/data`) and modify `app/database.py` to use a path in that directory (e.g., `sqlite:////data/bookstore.db`), preferably via an environment variable. If modifying `app/database.py` is forbidden, a bind-mount for the specific file may be required, but this "pollutes" the host as per the spec's own definition.
+
+### MEDIUM
+
+#### 1. Resolution of `bookstore.localhost`
+- **Severity:** MEDIUM
+- **Description:** While most modern browsers resolve `*.localhost` to `127.0.0.1`, this is not universal across all operating systems, DNS configurations, or CLI tools (like `curl`). Users on older systems or specific network setups may find the environment unreachable.
+- **Suggested Resolution:** Add a note to the Developer Guide instructions for Step 5 recommending the addition of `127.0.0.1 bookstore.localhost` to the host's `/etc/hosts` file as a troubleshooting step.
+
+#### 2. Uvicorn Reload in Docker
+- **Severity:** MEDIUM
+- **Description:** Uvicorn's `--reload` (using `watchfiles`) occasionally fails to detect changes on some host/container combinations (especially on macOS/Windows with certain file system drivers) unless polling is enabled.
+- **Suggested Resolution:** Mention `WATCHFILES_FORCE_POLLING=true` as an optional environment variable in the Developer Guide if hot-reload is not working for the user.
+
+### LOW
+
+#### 1. Production vs. Development Dockerfile
+- **Severity:** LOW
+- **Description:** The spec explicitly excludes production optimizations. However, using `python:3.12-slim` is a good choice. For consistency, explicitly using `python:3.12.2-slim` (or a specific patch version) would ensure more reproducible builds.
+- **Suggested Resolution:** Use a more specific base image tag.
+
+---
+
+## Conclusion
+
+The spec's architectural direction is sound, but the `Dockerfile` and `pyproject.toml` interplay is technically flawed in its current form and will prevent a successful build. Additionally, the data persistence goal requires either a modification to the application's database configuration or a compromise on host "pollution" (via bind-mounting the DB file).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  app:
+    build: .
+    volumes:
+      - ./app:/app/app
+      - bookstore_data:/data
+    environment:
+      - DATABASE_URL=sqlite:////data/bookstore.db
+      - WATCHFILES_FORCE_POLLING=true
+    ports:
+      - "8000:8000"
+
+  caddy:
+    image: caddy:2-alpine
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - app
+
+volumes:
+  bookstore_data:
+  caddy_data:
+  caddy_config:

--- a/docs/docker-dev-guide.md
+++ b/docs/docker-dev-guide.md
@@ -44,7 +44,7 @@ Tests run inside the container with all dev dependencies available:
 docker compose exec app pytest
 ```
 
-Tests use an in-memory SQLite database and do not affect the development database.
+Tests use an in-memory SQLite database for request handling. Note that the FastAPI lifespan may still initialize the persistent database schema on startup, but test data is fully isolated.
 
 ## Stopping the Environment
 

--- a/docs/docker-dev-guide.md
+++ b/docs/docker-dev-guide.md
@@ -1,0 +1,79 @@
+# Docker Development Guide
+
+This guide covers running the Bookstore API in Docker for local development.
+
+## Prerequisites
+
+- Docker Engine installed
+- Docker Compose plugin (`docker compose` command available)
+
+## Starting the Environment
+
+```bash
+docker compose up --build
+```
+
+This starts two services:
+
+- **app** — FastAPI application on port 8000 (direct access)
+- **caddy** — Reverse proxy with automatic TLS on port 443
+
+The first build pulls base images and installs dependencies. Subsequent starts are faster due to layer caching.
+
+## Accessing the API
+
+| URL | Description |
+|-----|-------------|
+| `https://bookstore.localhost` | API via Caddy (TLS) |
+| `https://bookstore.localhost/docs` | Swagger UI |
+| `http://localhost:8000` | Direct access (no TLS) |
+
+Your browser will warn about the self-signed certificate on first visit. Accept the certificate to proceed.
+
+## Hot-Reload
+
+The `app/` directory is bind-mounted into the container. When you edit any Python file in `app/` on your host machine, uvicorn detects the change and restarts automatically. No container rebuild needed.
+
+`WATCHFILES_FORCE_POLLING=true` is set by default in docker-compose.yml to ensure file change detection works reliably across all platforms, including macOS and Windows with Docker Desktop.
+
+## Running Tests
+
+Tests run inside the container with all dev dependencies available:
+
+```bash
+docker compose exec app pytest
+```
+
+Tests use an in-memory SQLite database and do not affect the development database.
+
+## Stopping the Environment
+
+```bash
+# Stop and remove containers (data persists in volumes)
+docker compose down
+
+# Stop and remove containers AND volumes (deletes all data)
+docker compose down -v
+```
+
+## Data Persistence
+
+The SQLite database is stored in a named Docker volume (`bookstore_data`). Data persists across `docker compose down` and `docker compose up` cycles. To reset the database, use `docker compose down -v` to remove the volume.
+
+## Troubleshooting
+
+### `bookstore.localhost` not resolving
+
+Most modern browsers resolve `*.localhost` to `127.0.0.1` automatically. If it doesn't work in your environment, add this to your `/etc/hosts` file (or `C:\Windows\System32\drivers\etc\hosts` on Windows):
+
+```
+127.0.0.1 bookstore.localhost
+```
+
+### Hot-reload not working
+
+The `WATCHFILES_FORCE_POLLING` environment variable is already set to `true` in `docker-compose.yml`. If changes still aren't detected, verify that you're editing files inside the `app/` directory (other directories are not mounted into the container).
+
+### Port conflicts
+
+If ports 80, 443, or 8000 are already in use, either stop the conflicting service or change the port mappings in `docker-compose.yml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=75.0.0"]
+build-backend = "setuptools.backends._legacy:_Backend"
+
 [project]
 name = "bookstore-api"
 version = "0.1.0"
@@ -15,6 +19,9 @@ dev = [
     "pytest>=8.0.0",
     "httpx>=0.27.0",
 ]
+
+[tool.setuptools.packages.find]
+include = ["app*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

- Dockerfile with Python 3.12-slim, dev dependencies (`.[dev]`), and uvicorn `--reload`
- docker-compose.yml with app + Caddy services, SQLite named volume, `WATCHFILES_FORCE_POLLING` for reliable hot-reload
- Caddy reverse proxy at `bookstore.localhost` with automatic internal TLS
- Developer guide at `docs/docker-dev-guide.md`
- `app/database.py` updated to read `DATABASE_URL` from environment (backward-compatible fallback)
- `pyproject.toml` updated with `[build-system]` and package scoping

Closes #3

**Spec:** `context/specs/3-docker-dev-environment/IMPLEMENTATION_SPEC.md`

### Files Changed

| File | Change |
|------|--------|
| `pyproject.toml` | Add build-system config and setuptools package scoping |
| `app/database.py` | Read DATABASE_URL from env with fallback |
| `.dockerignore` | New — exclude build context bloat |
| `Dockerfile` | New — Python dev container |
| `Caddyfile` | New — Caddy reverse proxy config |
| `docker-compose.yml` | New — orchestrate app + Caddy |
| `docs/docker-dev-guide.md` | New — developer guide |
| `context/SUMMARY.md` | Add completed spec entry |
| `context/specs/3-docker-dev-environment/README.md` | Mark spec-implement complete |

## Test plan

- [ ] `docker compose up --build` starts both containers without errors
- [ ] `https://bookstore.localhost/docs` loads Swagger UI (accept self-signed cert)
- [ ] Edit a file in `app/` on host → uvicorn auto-reloads in container
- [ ] `curl -k https://bookstore.localhost/books` returns valid JSON
- [ ] Create a book, `docker compose down && docker compose up`, verify book persists
- [ ] `docker compose exec app pytest` — all tests pass
- [ ] `docker compose down` stops cleanly
- [ ] App still runs without Docker (`DATABASE_URL` fallback works, tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)